### PR TITLE
Add a feature choosing the time of graph signals users want to see.

### DIFF
--- a/app/visualization_st.py
+++ b/app/visualization_st.py
@@ -6,6 +6,7 @@ from utils import (
     get_graph_variables,
     draw_graph_signals,
     show_empty_fig,
+    variables,
 )
 import streamlit as st
 
@@ -50,10 +51,17 @@ class AppVisGSP:
             _ = self._select_gs_time(slider_disabled=slider_disabled)
             show_empty_fig()
         else:
-            gs_variables = get_graph_variables(self._use_gs_fpath)
-            max_time = gs_variables.data.shape[1]
+            if (
+                variables.prev_use_gs_fpath
+                and variables.prev_use_gs_fpath == self._use_gs_fpath
+            ):
+                gs_variables = variables.gs_variables
+            else:
+                gs_variables = get_graph_variables(self._use_gs_fpath)
+                variables.prev_use_gs_fpath = self._use_gs_fpath
+                variables.gs_variables = gs_variables
             selected_time = self._select_gs_time(
-                slider_disabled=slider_disabled, max_value=max_time
+                slider_disabled=slider_disabled, max_value=gs_variables.max_time
             )
             draw_graph_signals(
                 G=gs_variables.G,

--- a/app/visualization_st.py
+++ b/app/visualization_st.py
@@ -1,5 +1,3 @@
-import numpy as np
-from pygsp import graphs
 from utils import (
     init_page_st,
     top_dir,
@@ -44,13 +42,31 @@ class AppVisGSP:
 
     def main_functions(self):
         st.write(f"Selcted Graph Signal: {self._selected_gs_data}")
-        if self._use_gs_fpath:
-            gs_variables = get_graph_variables(self._use_gs_fpath)
-            draw_graph_signals(
-                G=gs_variables.G, pos=gs_variables.pos, data=gs_variables.data[:, 0]
-            )
-        else:
+        slider_disabled = self._use_gs_fpath is None
+        if slider_disabled:
             st.warning(
                 "Please load the data of graph signals in the sidebar.", icon="⚠️"
             )
+            _ = self._select_gs_time(slider_disabled=slider_disabled)
             show_empty_fig()
+        else:
+            gs_variables = get_graph_variables(self._use_gs_fpath)
+            max_time = gs_variables.data.shape[1]
+            selected_time = self._select_gs_time(
+                slider_disabled=slider_disabled, max_value=max_time
+            )
+            draw_graph_signals(
+                G=gs_variables.G,
+                pos=gs_variables.pos,
+                data=gs_variables.data[:, selected_time],
+            )
+
+    def _select_gs_time(self, slider_disabled, max_value=1):
+        selected_time = st.slider(
+            label="Select the time of graph signals: ",
+            min_value=0,
+            max_value=max_value,
+            step=1,
+            disabled=slider_disabled,
+        )
+        return selected_time

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,3 +8,6 @@ from .utils import (
     show_empty_fig,
 )
 from .gs_variables import GraphVariables
+from .session_state_variables import SessionVariables
+
+variables = SessionVariables()

--- a/utils/gs_variables.py
+++ b/utils/gs_variables.py
@@ -12,6 +12,8 @@ class GraphVariables:
     data: np.ndarray
     pos: np.ndarray
     G: np.array = field(init=False)
+    max_time: int = field(init=False)
 
     def __post_init__(self):
         self.G = graphs.Graph(self.W)
+        self.max_time = self.data.shape[1] - 1

--- a/utils/session_state_variables.py
+++ b/utils/session_state_variables.py
@@ -1,0 +1,35 @@
+import streamlit as st
+import sys
+
+
+def _get_session_state(key=None, default=None):
+    if key is None:
+        key = sys._getframe(1).f_code.co_name  # The caller function name
+    if key in st.session_state:
+        return st.session_state[key]
+    else:
+        return default
+
+
+def _set_session_state(value, key=None):
+    if key is None:
+        key = sys._getframe(1).f_code.co_name  # The caller function name
+    st.session_state[key] = value
+
+
+class SessionVariables:
+    @property
+    def prev_use_gs_fpath(self):
+        return _get_session_state()
+
+    @prev_use_gs_fpath.setter
+    def prev_use_gs_fpath(self, value):
+        _set_session_state(value)
+
+    @property
+    def gs_variables(self):
+        return _get_session_state()
+
+    @gs_variables.setter
+    def gs_variables(self, value):
+        _set_session_state(value)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -92,7 +92,7 @@ def _st_graph_pyplot(
     else:
         nx.draw_networkx_nodes(G=graphD, pos=position_dict, node_size=10)
     nx.draw_networkx_edges(G=graphD, pos=position_dict, width=0.2)
-    st.pyplot(fig=fig)
+    st.pyplot(fig=fig, use_container_width=True)
 
 
 def show_empty_fig():


### PR DESCRIPTION
The slider of Streamlit was added to choose the time of graph signals as follows:

<img width="1100" alt="Screenshot 2024-05-21 at 11 08 38" src="https://github.com/Maki0806/app-gsp-traffic-dataset/assets/46641983/0ae78eb1-09af-46dd-a397-bc7f12443fca">

This slider is defined in the following part of `app/visualizaton_st.py`:

```py
    def _select_gs_time(self, slider_disabled, max_value=1):
        selected_time = st.slider(
            label="Select the time of graph signals: ",
            min_value=0,
            max_value=max_value,
            step=1,
            disabled=slider_disabled,
        )
        return selected_time
```

The above `max_value` is substituted with the column number of data of the loaded graph signals.